### PR TITLE
Disable auto-merge when creating deployment

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -100,6 +100,7 @@ async function run() {
             ref: branch,
             environment: 'chromatic',
             required_contexts: [],
+            auto_merge: false
         }).then(deployment => {
             deployment_id = deployment.data.id;
             return api.repos.createDeploymentStatus({


### PR DESCRIPTION
Github automatically creates a merge commit when deploying a branch which is unnecessary.