### PR TITLE
Remove unnecessary `yarn build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ it does NOT:
       steps:
       - uses: actions/checkout@v1
       - run: |
-          yarn && yarn build
+          yarn
       - uses: chromaui/action@v1
         with: 
           projectToken: <insert the chromatic projectToken here>


### PR DESCRIPTION
Not sure why this is here? Not every project will even have this script?