### PR TITLE
Issue 653 update usage actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/webpack-env": "^1.17.0"
   },
   "devDependencies": {
-    "@actions/core": "^1.5.0",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
- Update actions 
- Was getting error trying to install without a webpack config. Looks like this file may be in another repo or something 

`npm i`


```
npm i
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> chromatic@6.11.1 prepublish /Users/howardj/sites/action
> npm run build


> chromatic@6.11.1 build /Users/howardj/sites/action
> npm-run-all --serial -l bundle:**

[bundle:bin   ] 
[bundle:bin   ] > chromatic@6.11.1 bundle:bin /Users/howardj/sites/action
[bundle:bin   ] > webpack --config=webpack-bin.config.js && chmod +x ./bin/main.cjs
[bundle:bin   ] 
[bundle:bin   ] [webpack-cli] Failed to load '/Users/howardj/sites/action/webpack-bin.config.js' config
[bundle:bin   ] [webpack-cli] Error: Cannot find module '/Users/howardj/sites/action/webpack-bin.config.js'
[bundle:bin   ] Require stack:
[bundle:bin   ] - /Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js
[bundle:bin   ] - /Users/howardj/sites/action/node_modules/webpack-cli/lib/bootstrap.js
[bundle:bin   ] - /Users/howardj/sites/action/node_modules/webpack-cli/bin/cli.js
[bundle:bin   ] - /Users/howardj/sites/action/node_modules/webpack/bin/webpack.js
[bundle:bin   ]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
[bundle:bin   ]     at Function.Module._load (internal/modules/cjs/loader.js:667:27)
[bundle:bin   ]     at Module.require (internal/modules/cjs/loader.js:887:19)
[bundle:bin   ]     at require (internal/modules/cjs/helpers.js:74:18)
[bundle:bin   ]     at WebpackCLI.tryRequireThenImport (/Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js:204:22)
[bundle:bin   ]     at loadConfigByPath (/Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js:1404:38)
[bundle:bin   ]     at /Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js:1454:88
[bundle:bin   ]     at Array.map (<anonymous>)
[bundle:bin   ]     at WebpackCLI.loadConfig (/Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js:1454:68)
[bundle:bin   ]     at WebpackCLI.createCompiler (/Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js:1785:33) {
[bundle:bin   ]   code: 'MODULE_NOT_FOUND',
[bundle:bin   ]   requireStack: [
[bundle:bin   ]     '/Users/howardj/sites/action/node_modules/webpack-cli/lib/webpack-cli.js',
[bundle:bin   ]     '/Users/howardj/sites/action/node_modules/webpack-cli/lib/bootstrap.js',
[bundle:bin   ]     '/Users/howardj/sites/action/node_modules/webpack-cli/bin/cli.js',
[bundle:bin   ]     '/Users/howardj/sites/action/node_modules/webpack/bin/webpack.js'
[bundle:bin   ]   ]
[bundle:bin   ] }
[bundle:bin   ] npm ERR! code ELIFECYCLE
[bundle:bin   ] npm ERR! errno 2
[bundle:bin   ] npm ERR! chromatic@6.11.1 bundle:bin: `webpack --config=webpack-bin.config.js && chmod +x ./bin/main.cjs`
[bundle:bin   ] npm ERR! Exit status 2
[bundle:bin   ] npm ERR! 
[bundle:bin   ] npm ERR! Failed at the chromatic@6.11.1 bundle:bin script.
[bundle:bin   ] npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
[bundle:bin   ] 
[bundle:bin   ] npm ERR! A complete log of this run can be found in:
[bundle:bin   ] npm ERR!     /Users/howardj/.npm/_logs/2022-10-26T15_12_10_807Z-debug.log
ERROR: "bundle:bin" exited with 2.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chromatic@6.11.1 build: `npm-run-all --serial -l bundle:**`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the chromatic@6.11.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/howardj/.npm/_logs/2022-10-26T15_12_10_854Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chromatic@6.11.1 prepublish: `npm run build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the chromatic@6.11.1 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/howardj/.npm/_logs/2022-10-26T15_12_10_938Z-debug.log
